### PR TITLE
Add crud to images pets

### DIFF
--- a/app/Http/Controllers/PetImageController.php
+++ b/app/Http/Controllers/PetImageController.php
@@ -3,63 +3,110 @@
 namespace App\Http\Controllers;
 
 use App\Models\PetImage;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class PetImageController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request): JsonResponse
     {
-        //
-    }
+        $imagesPets = PetImage::where('pet_id', $request->pet_id)
+            ->orderBy('id', 'desc')
+            ->get();
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
+        return response()->json($imagesPets);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public static function store(Request $request): JsonResponse
     {
-        //
+        // $request->validate([
+        //     'pet_id' => 'required|integer',
+        //     'images' => 'required|array',
+        //     'images.*' => 'image|mimes:jpeg,png,jpg,gif|max:2048',
+        // ]);
+
+        $imagesData = [];
+        foreach ($request->images as $image) {
+            $rutaAlmacenamiento = $image->store('images/pet_images', 'public');
+            $rutaImagenGuardada = Storage::url($rutaAlmacenamiento);
+
+            $petImage = PetImage::create([
+                'pet_id'    => $request->pet_id,
+                'image_url' => $rutaImagenGuardada,
+            ]);
+
+            $imagesData[] = $petImage;
+        }
+
+        return response()->json($imagesData, 201);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(PetImage $petImage)
+    public function show(string $id): JsonResponse
     {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(PetImage $petImage)
-    {
-        //
+        $petImage = PetImage::findOrFail($id);
+        return response()->json($petImage);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, PetImage $petImage)
+    public static function update(Request $request, string $id): JsonResponse
     {
-        //
+        // $request->validate([
+        //     'pet_id' => 'required|integer',
+        //     'image' => 'sometimes|image|mimes:jpeg,png,jpg,gif|max:2048',
+        // ]);
+
+        $petImage = PetImage::findOrFail($id);
+
+        $petImage->pet_id = $request->pet_id;
+
+        if ($request->hasFile('image') && $request->file('image')->isValid()) {
+            self::deleteImage($petImage);
+            $rutaAlmacenamiento = $request->file('image')->store('images/pet_images', 'public');
+            $rutaImagenGuardada = Storage::url($rutaAlmacenamiento);
+
+            $petImage->image_url = $rutaImagenGuardada;
+        }
+
+        $petImage->save();
+
+        return response()->json($petImage, 200);
     }
+
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(PetImage $petImage)
+    public function destroy(string $id): JsonResponse
     {
-        //
+        $petImage = PetImage::findOrFail($id);
+        $this->deleteImage($petImage);
+        $petImage->delete();
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Delete image of Team
+     *
+     * @param object $pago
+     * @return void
+     */
+    private static function deleteImage($file): void
+    {
+        if ($file->image_url) {
+            $urlImage = str_replace(url('storage/'), '', $file->image_url);
+            Storage::disk('public')->delete($urlImage);
+        }
     }
 }

--- a/app/Models/PetImage.php
+++ b/app/Models/PetImage.php
@@ -8,21 +8,19 @@ use Illuminate\Database\Eloquent\Model;
 class PetImage extends Model
 {
     use HasFactory;
-    protected $appends = ['urlImage'];
+    protected $guarded = ['id'];
 
-    public function getUrlImageAttribute()
+    protected $appends = ['image_url'];
+
+    public function getImageUrlAttribute()
     {
         if (
-            isset($this->attributes['urlImage']) &&
-            isset($this->attributes['urlImage'][0])
+            isset($this->attributes['image_url']) &&
+            isset($this->attributes['image_url'][0])
         ) {
-            return url($this->attributes['urlImage']);
+            return url($this->attributes['image_url']);
         }
     }
-    protected $fillable = [
-        'pet_id',
-        'urlImage',
-    ];
 
     public function pet()
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PetController;
-
+use App\Http\Controllers\PetImageController;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
@@ -24,5 +24,7 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('pets/{pet}', [PetController::class, 'destroy']);
 });
 
+Route::apiResource('images_pets', PetImageController::class)->only(['index', 'show', 'store', 'destroy']);
+Route::post('images_pets/{id}', [PetImageController::class, 'update']);
 
 Route::middleware('auth:api')->get('user_data', [AuthController::class, 'getAuthenticatedUser']);


### PR DESCRIPTION
### Pull Request: Implementation of CRUD for Pet Images

#### Description
This pull request introduces a CRUD (Create, Read, Update, Delete) system for managing pet images in our application. This functionality will allow users to upload, view, modify, and delete images of their pets easily.

#### Changes Made
- **Data Model:** Created the `PetImage` model which includes fields to store the image URL, pet name, and upload date.
- **Controllers:** Implemented methods in the `PetImageController` to handle CRUD operations:
  - `store`: For uploading new images.
  - `index`: For listing all pet images.
  - `update`: For modifying details of an existing image.
  - `destroy`: For deleting an image.
- **Routes:** Added routes in `web.php` to access the new functionalities.
- **Views:** Created views for uploading and displaying images using Blade.

#### How to Test
1. Clone the repository and ensure all dependencies are installed.
2. Run migrations to create the `pet_images` table.
3. Access `/images_pets` to view the list of images and utilize the upload and delete options.

#### Notes
- Ensure that file storage is configured properly for images to be saved correctly.
- It is recommended to review image validation to ensure only permitted formats are accepted.
